### PR TITLE
fix: Usage of `bilingual-bibliography`

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -425,7 +425,7 @@ aaa 在第 #my-link(<233>) 页
 #import "@preview/modern-nju-thesis:0.3.4": bilingual-bibliography
 
 // 将原本的 #bibliography("refs.bib") 替换为
-#bilingual-bibliography(bibliography: "refs.bib")
+#bilingual-bibliography(bibliography: bibliography.with("refs.bib"))
 ```
 
 ## 如何让几个汉字占固定宽度并均匀分布？ {#character-intersperse}


### PR DESCRIPTION
更正`bilingual-bibliography`示例，这里应该传个函数。

```log
expected function, found string
```

https://github.com/nju-lug/modern-nju-thesis/blob/79c658a55437809482fa77f44a50a887935d74a4/utils/bilingual-bibliography.typ#L139-L143