### PR TITLE
标题有特殊语法时难以渲染，改为手动指定 FAQList 中项目

### DIFF
--- a/docs/.vitepress/theme/faqlist.data.ts
+++ b/docs/.vitepress/theme/faqlist.data.ts
@@ -23,8 +23,9 @@ export default createContentLoader('FAQ/*.md', {
     const tagMap = {};
 
     const posts = rawData.map(({ src, url, frontmatter }) => {
-      // get the title from md source code
-      const title = src?.match(/# (.*)/)?.[1] ?? url;
+      // 一般 title 用“# …”即可；
+      // 不过偶尔用了markdown特殊语法，难以渲染，这时改用 frontmatter 手动指定
+      const title = frontmatter.title ?? src?.match(/# (.*)/)?.[1] ??  url;
       const result = {
         title,
         url,

--- a/docs/FAQ/bib-csl.md
+++ b/docs/FAQ/bib-csl.md
@@ -1,5 +1,6 @@
 ---
 tags: [bib]
+title: 为什么指定参考文献 CSL 后，报错“failed to load CSL style”？
 ---
 # 为什么指定参考文献 CSL 后，报错`failed to load CSL style`？
 

--- a/docs/FAQ/symbol-mathscr.md
+++ b/docs/FAQ/symbol-mathscr.md
@@ -1,5 +1,6 @@
 ---
 tags: [math]
+title: 如何实现 \mathscr 的花体符号？
 ---
 # 如何实现 `\mathscr` 的花体符号？
 


### PR DESCRIPTION
VitePress 渲染 markdown 的讨论：
https://github.com/vuejs/vitepress/discussions/2050

可用以下正则表达式搜索一级标题里的特殊语法。

    ^# .+[`*_]
