### PR TITLE
fix example in sub-figure.md

### DIFF
--- a/docs/FAQ/sub-figure.md
+++ b/docs/FAQ/sub-figure.md
@@ -46,6 +46,8 @@ https://typst.app/universe/package/subpar/
 
 ```typst
 #set page(width: 12cm, height: auto)
+#import "@preview/i-figured:0.2.4"
+#show figure: i-figured.show-figure
 #figure(grid(columns: 2, gutter: 1em,
   figure(rect(), numbering: none, caption: [a) demo1]),
   figure(rect(), numbering: none, caption: [b) demo2]),


### PR DESCRIPTION
常见问题中，`i-figured`与`typst grid`冲突的例子少了`i-figured`的引用