### PR TITLE
refactor: Add log in the typst render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ dist-ssr
 
 docs/.vitepress/cache
 generated
-tmp.typ

--- a/docs/.vitepress/typst_render.ts
+++ b/docs/.vitepress/typst_render.ts
@@ -1,48 +1,117 @@
 import MarkdownIt from 'markdown-it';
-import { createHash } from 'crypto';
-import { writeFileSync, existsSync, mkdirSync } from 'fs';
-import { execSync } from 'child_process';
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 
-function compileTypst(src: string) {
+import { prettify, readToString } from './util';
+
+type CompileResult = {
+  /** 输入一系列 PNG 的路径 */
+  pages: string[];
+  /** typst 生成的日志（通常无任何警告或错误） */
+  log?: string;
+};
+
+/**
+ * 用 typst 编译
+ *
+ * 若已编译，会复用先前结果。
+ *
+ * @param src 源文档的内容，不含导言
+ * @param info 源文档的位置信息，仅用于报错提示
+ * @returns 编译结果
+ */
+function compileTypst(
+  src: string,
+  info: { path: string; line_begin?: number },
+): CompileResult {
+  // 输出设置
+
   // 计算源码的 SHA1 哈希值
-  const hash = createHash('sha1').update(src).digest('hex').substr(0, 10);
-  const outprefix = 'docs/generated/';
-  const outfilename = `${outprefix}${hash}_{n}.png`;
+  const hash = createHash('sha1').update(src).digest('hex').slice(0, 10);
+  const outPrefix = 'docs/generated/';
+  const pageFilePattern = `${outPrefix}${hash}_{n}.png`;
+  const logFile = `${outPrefix}${hash}.log`;
+
+  // 输入设置
+
   const template = `#set page(height: 4cm, width: 6cm)
 #set text(font: ("New Computer Modern", "Source Han Serif SC"))
 <<src>>`;
+  const srcFull = template.replace('<<src>>', src);
 
-  // 将源码字符串写入 tmp.typ 文件中
-  const tmpFilePath = 'tmp.typ';
-  writeFileSync(tmpFilePath, template.replace('<<src>>', src));
+  // 编译
 
-  // 替换 {n} 为 1 并判断文件是否存在
-  const firstOutFile = outfilename.replace('{n}', "1");
-  if (!existsSync(firstOutFile)) {
-    // 调用 typst 编译命令
-    try {
-      // 确保 prefix 文件夹存在
-      if (!existsSync(outprefix)) {
-        mkdirSync(outprefix, { recursive: true });
-      }
-      execSync(`typst compile ${tmpFilePath} ${outfilename} --font-path fonts`);
-    } catch (error) {
-      console.error('Error compiling Typst file:', error);
+  // 若存在文件，不再重复编译
+  const compiled = [
+    pageFilePattern.replace('{n}', '1'), // 首页
+    logFile,
+  ].some(existsSync);
+
+  if (!compiled) {
+    // 确保输出文件夹存在（若已存在，会忽略）
+    mkdirSync(outPrefix, { recursive: true });
+
+    // 编译
+    const { stderr, stdout } = spawnSync('typst', [
+      'compile',
+      '-', // 用 stdin 输入，这样文档多了后容易改成并发
+      pageFilePattern,
+      '--font-path',
+      'fonts',
+    ], {
+      input: srcFull,
+    });
+
+    // 正常应该没有 stdout；不过以防万一，检查一下
+    assert(stdout.length === 0);
+
+    // 保存日志
+    if (stderr.length > 0) {
+      writeFileSync(logFile, stderr);
     }
   }
 
+  // 收集结果
+
   // 遍历输出文件名，检查文件是否存在
-  const outputFiles: string[] = [];
+  const pages: string[] = [];
   for (let n = 1; n < 10; n++) {
-    const currentOutFile = outfilename.replace('{n}', String(n));
-    if (existsSync(currentOutFile)) {
+    const page = pageFilePattern.replace('{n}', String(n));
+    if (existsSync(page)) {
       // remove 'docs/' prefix
-      outputFiles.push(currentOutFile.replace('docs/', '/'));
+      pages.push(page.replace('docs/', '/'));
     } else {
       break;
     }
   }
-  return outputFiles;
+
+  // 读取日志，适当报错
+  const log = readToString(logFile)?.replaceAll(
+    // 删除日志中的无用路径（编译时的工作目录）
+    /(  ┌─ ).+(<stdin>:)/g,
+    '$1$2',
+  )?.replaceAll(
+    // 删除下载包的记录
+    /(^|\n)downloading @preview\/.+\n.+ ETA: 0 s($|\n)/g,
+    '',
+  )?.trim();
+  if (log) {
+    let location = info.path;
+    if (info.line_begin) {
+      location += `:${info.line_begin}`;
+    }
+    console.error([
+      `Error compiling Typst document:`,
+      `  Source (starting at ${location}):`,
+      prettify(src, { indent: '    ', max_lines: 4 }),
+      `  Log (${logFile}):`,
+      prettify(log, { indent: '    ', max_lines: 8 }),
+    ].join('\n'));
+  }
+
+  return { pages, log };
 }
 
 function TypstRender(md: MarkdownIt) {
@@ -54,10 +123,24 @@ function TypstRender(md: MarkdownIt) {
     const token = tokens[idx];
     if (token.info.trim() === 'typst') {
       const src = token.content;
-      const imgPaths = compileTypst(src);
+      const result = compileTypst(src, {
+        path: `docs/${env.relativePath}`,
+        // 加四是因为 front matter
+        line_begin: token.map ? token.map[0] + 4 : undefined,
+      });
+
       const codeHtml = defaultRender(tokens, idx, options, env, self);
-      const imagesHtml = imgPaths.map(path => `<img src="${path}" alt="Typst compiled image"/>`).join('');
-      return `${codeHtml}${imagesHtml}`;
+
+      const imagesHtml = result.pages.map((path) =>
+        `<img src="${path}" alt="Typst compiled image"/>`
+      ).join('');
+
+      const logHtml = result.log
+        // 日志本身可能已经含“```”，故用四个“`”。
+        ? md.render(['````log', result.log, '````'].join('\n'))
+        : '';
+
+      return `${codeHtml}${imagesHtml}${logHtml}`;
     }
     return defaultRender(tokens, idx, options, env, self);
   };

--- a/docs/.vitepress/util.ts
+++ b/docs/.vitepress/util.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Read a file to string, return `undefined` if not existed
+ */
+export function readToString(file: string): string | undefined {
+  try {
+    return readFileSync(file, { encoding: 'utf-8' });
+  } catch (err) {
+    // If not existed
+    if (err.code === 'ENOENT') {
+      return;
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
+ * 格式化`doc`
+ * - 每行前加`indent`
+ * - 最多显示`max_lines`行，多余时加`…`
+ */
+export function prettify(
+  doc: string,
+  { indent, max_lines }: { indent: string; max_lines: number },
+): string {
+  let lines = doc.split('\n');
+  if (lines.length > max_lines) {
+    lines = lines.slice(0, max_lines - 1).concat('…');
+  }
+  return lines.map((l) => `${indent}${l}`).join('\n');
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "serve": "vitepress serve docs"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.1.2",
+    "@types/node": "^22.13.1",
     "@waline/client": "^3.5.1",
     "unocss": "^0.63.6",
     "vitepress": "^1.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,15 +12,21 @@ importers:
         specifier: ^14.1.0
         version: 14.1.0
     devDependencies:
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
+      '@types/node':
+        specifier: ^22.13.1
+        version: 22.13.1
       '@waline/client':
         specifier: ^3.5.1
         version: 3.5.1
       unocss:
         specifier: ^0.63.6
-        version: 0.63.6(postcss@8.5.1)(rollup@4.32.0)(vite@5.4.14)
+        version: 0.63.6(postcss@8.5.1)(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1))
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.3(@algolia/client-search@5.20.0)(postcss@8.5.1)(search-insights@2.16.3)
+        version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.13.1)(postcss@8.5.1)(search-insights@2.16.3)
       vue:
         specifier: ^3.5.13
         version: 3.5.13
@@ -504,51 +510,61 @@ packages:
     resolution: {integrity: sha512-3pA7xecItbgOs1A5H58dDvOUEboG5UfpTq3WzAdF54acBbUM+olDJAPkgj1GRJ4ZqE12DZ9/hNS2QZk166v92A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.32.0':
     resolution: {integrity: sha512-Y7XUZEVISGyge51QbYyYAEHwpGgmRrAxQXO3siyYo2kmaj72USSG8LtlQQgAtlGfxYiOwu+2BdbPjzEpcOpRmQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.32.0':
     resolution: {integrity: sha512-r7/OTF5MqeBrZo5omPXcTnjvv1GsrdH8a8RerARvDFiDwFpDVDnJyByYM/nX+mvks8XXsgPUxkwe/ltaX2VH7w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.32.0':
     resolution: {integrity: sha512-HJbifC9vex9NqnlodV2BHVFNuzKL5OnsV2dvTw6e1dpZKkNjPG6WUq+nhEYV6Hv2Bv++BXkwcyoGlXnPrjAKXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.32.0':
     resolution: {integrity: sha512-VAEzZTD63YglFlWwRj3taofmkV1V3xhebDXffon7msNz4b14xKsz7utO6F8F4cqt8K/ktTl9rm88yryvDpsfOw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.32.0':
     resolution: {integrity: sha512-Sts5DST1jXAc9YH/iik1C9QRsLcCoOScf3dfbY5i4kH9RJpKxiTBXqm7qU5O6zTXBTEZry69bGszr3SMgYmMcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.32.0':
     resolution: {integrity: sha512-qhlXeV9AqxIyY9/R1h1hBD6eMvQCO34ZmdYvry/K+/MBs6d1nRFLm6BOiITLVI+nFAAB9kUB6sdJRKyVHXnqZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.32.0':
     resolution: {integrity: sha512-8ZGN7ExnV0qjXa155Rsfi6H8M4iBBwNLBM9lcVS+4NcSzOFaNqmt7djlox8pN1lWrRPMRRQ8NeDlozIGx3Omsw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.32.0':
     resolution: {integrity: sha512-VDzNHtLLI5s7xd/VubyS10mq6TxvZBp+4NRWoW+Hi3tgV05RtVm4qK99+dClwTN1McA6PHwob6DEJ6PlXbY83A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.32.0':
     resolution: {integrity: sha512-qcb9qYDlkxz9DxJo7SDhWxTWV1gFuwznjbTiov289pASxlfGbaOD54mgbs9+z94VwrXtKTu+2RqwlSTbiOqxGg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.32.0':
     resolution: {integrity: sha512-pFDdotFDMXW2AXVbfdUEfidPAk/OtwE/Hd4eYMTNVVaCQ6Yl8et0meDaKNL63L44Haxv4UExpv9ydSf3aSayDg==}
@@ -606,6 +622,9 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/node@22.13.1':
+    resolution: {integrity: sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1221,6 +1240,9 @@ packages:
   unconfig@0.5.5:
     resolution: {integrity: sha512-VQZ5PT9HDX+qag0XdgQi8tJepPhXiR/yVOkn707gJDKo31lGjRilPREiQJ9Z6zd/Ugpv6ZvO5VxVIcatldYcNQ==}
 
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
 
@@ -1770,19 +1792,23 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/node@22.13.1':
+    dependencies:
+      undici-types: 6.20.0
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.20': {}
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@unocss/astro@0.63.6(rollup@4.32.0)(vite@5.4.14)':
+  '@unocss/astro@0.63.6(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1))':
     dependencies:
       '@unocss/core': 0.63.6
       '@unocss/reset': 0.63.6
-      '@unocss/vite': 0.63.6(rollup@4.32.0)(vite@5.4.14)
+      '@unocss/vite': 0.63.6(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1))
     optionalDependencies:
-      vite: 5.4.14
+      vite: 5.4.14(@types/node@22.13.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -1911,7 +1937,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.63.6
 
-  '@unocss/vite@0.63.6(rollup@4.32.0)(vite@5.4.14)':
+  '@unocss/vite@0.63.6(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@4.32.0)
@@ -1921,15 +1947,15 @@ snapshots:
       chokidar: 3.6.0
       magic-string: 0.30.17
       tinyglobby: 0.2.10
-      vite: 5.4.14
+      vite: 5.4.14(@types/node@22.13.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.14)(vue@3.5.13)':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.13.1))(vue@3.5.13)':
     dependencies:
-      vite: 5.4.14
+      vite: 5.4.14(@types/node@22.13.1)
       vue: 3.5.13
 
   '@vue/compiler-core@3.5.13':
@@ -2528,6 +2554,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  undici-types@6.20.0: {}
+
   unist-util-is@6.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -2551,9 +2579,9 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  unocss@0.63.6(postcss@8.5.1)(rollup@4.32.0)(vite@5.4.14):
+  unocss@0.63.6(postcss@8.5.1)(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1)):
     dependencies:
-      '@unocss/astro': 0.63.6(rollup@4.32.0)(vite@5.4.14)
+      '@unocss/astro': 0.63.6(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1))
       '@unocss/cli': 0.63.6(rollup@4.32.0)
       '@unocss/core': 0.63.6
       '@unocss/postcss': 0.63.6(postcss@8.5.1)
@@ -2569,9 +2597,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.63.6
       '@unocss/transformer-directives': 0.63.6
       '@unocss/transformer-variant-group': 0.63.6
-      '@unocss/vite': 0.63.6(rollup@4.32.0)(vite@5.4.14)
+      '@unocss/vite': 0.63.6(rollup@4.32.0)(vite@5.4.14(@types/node@22.13.1))
     optionalDependencies:
-      vite: 5.4.14
+      vite: 5.4.14(@types/node@22.13.1)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -2588,15 +2616,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@5.4.14:
+  vite@5.4.14(@types/node@22.13.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.32.0
     optionalDependencies:
+      '@types/node': 22.13.1
       fsevents: 2.3.3
 
-  vitepress@1.6.3(@algolia/client-search@5.20.0)(postcss@8.5.1)(search-insights@2.16.3):
+  vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.13.1)(postcss@8.5.1)(search-insights@2.16.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.20.0)(search-insights@2.16.3)
@@ -2605,7 +2634,7 @@ snapshots:
       '@shikijs/transformers': 2.1.0
       '@shikijs/types': 2.1.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14)(vue@3.5.13)
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.13.1))(vue@3.5.13)
       '@vue/devtools-api': 7.7.1
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0
@@ -2614,7 +2643,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.1.0
-      vite: 5.4.14
+      vite: 5.4.14(@types/node@22.13.1)
       vue: 3.5.13
     optionalDependencies:
       postcss: 8.5.1


### PR DESCRIPTION
Resolves #36

## 效果

```log
Error compiling Typst document:
  Source (starting at docs/FAQ/heading-various-format.md:10):
    #let chapter(title) = {
      heading(
        level: 1,
    …
  Log (docs/generated/4174e0db62.log):
    warning: `counter.display` without context is deprecated
      ┌─ <stdin>:8:6
      │
    8 │       counter("chapter").display("第一章")
      │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
      = hint: use it in a `context` expression instead
    …
```

[`/FAQ/heading-various-format.html`](https://deploy-preview-45--luxury-mochi-9269a9.netlify.app/FAQ/heading-various-format.html)

<details>
<summary>截图</summary>

![图片](https://github.com/user-attachments/assets/4e552c11-504e-482e-8997-0b6d82c1d1f5)

</details>

## 实现细节

- 抛弃`tmp.typ`，改用 stdin 输入给 typst。
- 如果 typst 输出了 stderr，保存到与PNG同名的`*.log`。
- 在`pnpm dev`后台，打印源文档和 stderr（的节选），并给出文件链接。
- 在网页上，在PNG之后加上代码块，内容为 stderr，语言为 log。

<!--
## 已知的问题

下载包的过程也被记录下来了……

https://app.netlify.com/sites/luxury-mochi-9269a9/deploys/67a3d5461d1a9c0008d023f5#L458-L466

```log
5:20:02 AM:     downloading @preview/whalogen:0.2.0
5:20:02 AM:       6.3 KiB /   6.3 KiB (100 %)   6.3 KiB/s in 15.79 µs ETA: 0 s
5:20:02 AM:     downloading @preview/xarrow:0.3.1
5:20:02 AM:       3.4 KiB /   3.4 KiB (100 %)   3.4 KiB/s in 19.14 µs ETA: 0 s
```

`pnpm build && rm docs/generated && pnpm build`可解决，不知能否接受？
-->