### PR TITLE
修复警告并更新情况

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,7 +26,7 @@
 
 https://github.com/typst-doc-cn/guide/new/master/docs/FAQ
 
-模板如下：
+:::: details 模板
 
 ````md
 ---
@@ -66,3 +66,15 @@ $ sum_(k=1)^n k = (n(n+1)) / 2 $
 #set page(height: 4cm, width: 6cm)
 #set text(font: ("New Computer Modern", "Source Han Serif SC"))
 ```
+
+另外，如果问题已在新版 typst 修复或改进，可在标题开头添加`【已修复】`，并注明版本。
+
+```md
+# 【已修复】……？
+
+::: tip ✅ Typst 0.0 已修复/已改进
+[#000](https://github.com/typst/typst/pull/000) 已经……
+:::
+```
+
+::::

--- a/docs/FAQ/bib-detail.md
+++ b/docs/FAQ/bib-detail.md
@@ -21,6 +21,10 @@ Typst 暂不支持 `school` `institution` 作为 `publisher` 的别名，亦不�
   }
 ```
 
-## 引文条目中 `. ` 部分丢失。
+## 【已修复】引文条目中 `. `、`: ` 部分丢失。
+
+::: tip ✅ Typst 0.13 已修复
+[hayagriva#269](https://github.com/typst/hayagriva/pull/269) 已经改正了 CSL 中`<choose>`和`<layout>`中分隔符的实现方法。
+:::
 
 在 CSL 中修改生成引文条目的 `macro`，向缺少 `. ` 的部分添加 `<group delimiter=". ">`。

--- a/docs/FAQ/chinese-in-raw.md
+++ b/docs/FAQ/chinese-in-raw.md
@@ -4,9 +4,29 @@ tags: [font, chinese, raw]
 
 # 为什么代码块里面的中文字体显示不正常？
 
-首先，请参考 [为什么中文字体这么奇怪](./strange-fonts.md) 对正文字体进行配置。
+首先，请参考 [为什么中文字体这么奇怪](./strange-fonts.md) 配置正文字体。
 
-然后，对于代码块，需要在源代码文件中使用类似的命令设置字体：
+::: tip ✅ Typst 0.13 已改进
+[#4889](https://github.com/typst/typst/pull/4889)、[#5305](https://github.com/typst/typst/pull/5305)、[#5753](https://github.com/typst/typst/pull/5753) 已改进默认情况。
+
+配置正文字体后，请继续设置代码块的字体：
+
+```typst no-render
+#show raw : set text(font: (
+  (name: "DejaVu Sans Mono", covers: "latin-in-cjk"),
+  "Noto Sans CJK SC",
+))
+```
+
+- 「DejaVu Sans Mono」是等宽字体，负责 `123`、`abc`、`,"!、{}()` 等
+- 「Noto Sans CJK SC」是 CJK 字体，负责汉字和`，“”！`等
+
+此外，请**不要**设置 `#show raw: set text(fallback: false)`。
+:::
+
+如果你使用旧版本，请使用以下旧方案。
+
+配置正文字体后，对于代码块，需要在源代码文件中使用类似的命令设置字体：
 
 ```typst no-render
 #show raw : set text(font: ("DejaVu Sans Mono", "Noto Sans CJK SC"))
@@ -16,11 +36,11 @@ tags: [font, chinese, raw]
 
 因此，你需要需要保证你没有如 `#show raw: set text(fallback: false)` 的命令在你的文档中。**同时**要保证你的等宽字体中没有任何的 CJK 字符，否则会造成中文字体不统一。
 
-相关 issue（已由 [\#5753](https://github.com/typst/typst/pull/5753) 修复）：https://github.com/typst/typst/issues/5748
-
 ![示例](../images/chinese-in-raw.png)
 
 ## 相关内容
 
 - [代码块里多了空格/代码块的对齐非常奇怪](./code-block-justify.md)
 - [【已修复】代码块中西文间有多余的空格](./cjk-latin-spacing-in-raw.md)
+
+<!-- 汉字默认等宽字体 https://github.com/typst/typst/issues/3385 -->

--- a/docs/FAQ/chinese-skew.md
+++ b/docs/FAQ/chinese-skew.md
@@ -9,7 +9,8 @@ tags: chinese
 一般使用其他字体（如楷体）代替斜体：
 
 ```typst
-#show emph: text.with(font: ("（西文字体）", "STKaiti"))
+#let 西文字体 = "Libertinus Serif"
+#show emph: text.with(font: (西文字体, "Kaiti"))
 孔乙己_上大人_
 ```
 
@@ -21,8 +22,6 @@ tags: chinese
 ```
 但是针对一大段效果并不好。
 ```typst
-#set text(font: ("New Computer Modern", "Noto Serif CJK SC"), lang: "zh")
-
 #skew(ax: -12deg)[
   Typst 是可用于出版的可编程标记语言，拥有变量、函数、包管理与错误检查等现代编程语言的特性，同时也提供了闭包等特性，便于进行函数式编程。以及包括了 [标记模式]、{脚本模式} 与 数学模式 等多种模式的作用域，并且它们可以不限深度地、交互地嵌套。并且通过 包管理，你不再需要像 TexLive 一样在本地安装一大堆并不必要的宏包，而是按需自动从云端下载。
 ]

--- a/docs/FAQ/cjk-latin-spacing-in-raw.md
+++ b/docs/FAQ/cjk-latin-spacing-in-raw.md
@@ -27,7 +27,7 @@ printf("这是%d段代码", 1);
 就是有害的。因为在这种情况下，如果我们在编译的结果中在 `%d` 和 `段代码` 之间添加一个空格，它有歧义，因为我们无法判断它是否是一个空格还是一个中西文间距。
 
 ```typst
-#show raw: set text(font: ("Monospace", "Source Han Serif SC"))
+#show raw: set text(font: ("DejaVu Sans Mono", "Source Han Serif SC"))
 #raw(lang: "cpp", "printf(\"这是%d段代码\", 1)")
 ```
 

--- a/docs/FAQ/cjk-latin-spacing-in-raw.md
+++ b/docs/FAQ/cjk-latin-spacing-in-raw.md
@@ -4,8 +4,8 @@ tags: [font, chinese, raw, bug, spacing, layout]
 
 # 【已修复】代码块中西文间有多余的空格？
 
-::: tip
-[\#5753](https://github.com/typst/typst/pull/5753) 已设置默认 cjk-latin-spacing 在 raw 中为 false，因此相关问题在 0.13 应该不会再出现。
+::: tip ✅ Typst 0.13 已修复
+[\#5753](https://github.com/typst/typst/pull/5753) 已默认设置 `cjk-latin-spacing` 在 `raw` 中为 `false`。
 :::
 
 首先，你可能需要参考 [为什么中文字体这么奇怪](./strange-fonts.md) 对正文字体进行配置。然后参照 [为什么代码块里面的中文字体显示不正常？](./chinese-in-raw.md) 对于代码块内中文的进行修改。

--- a/docs/FAQ/code-block-justify.md
+++ b/docs/FAQ/code-block-justify.md
@@ -2,7 +2,11 @@
 tags: [code, layout]
 ---
 
-# 代码块里多了空格/代码块的对齐非常奇怪
+# 【已修复】代码块里多了空格/代码块的对齐非常奇怪
+
+::: tip ✅ Typst 0.13 已修复
+[#4889](https://github.com/typst/typst/pull/4889) 已给 `raw` 默认设置 `set par(just: false)`。
+:::
 
 给 `par` 设置两端对齐时，同时也会影响代码块，因为代码块的本质也是 `par`，所以要手动关掉代码块的两端对齐。
 

--- a/docs/FAQ/first-line-indent.md
+++ b/docs/FAQ/first-line-indent.md
@@ -1,15 +1,21 @@
 ---
 tags: [layout]
 ---
-# 为什么第一段没有缩进？
+# 【已修复】为什么第一段没有缩进？
 
-<details>
-<summary>参考阅读：</summary>
-Typst 官方也意识到了这个问题，希望我们可以早日看见这一问题的解决。
+::: tip ✅ Typst 0.13 已修复
+[#5768](https://github.com/typst/typst/pull/5768) 增加了 `all` 选项，可以缩进所有段落了。
 
-Tracking Issue：https://github.com/typst/typst/issues/311
+```typst
+#set par(first-line-indent: (amount: 2em, all: true))
 
-</details>
+= 标题
+
+首段也缩进了。
+
+之后段落原本已缩进。
+```
+:::
 
 首先，英文排版是这样的，LaTeX 默认第一段也是不缩进的。其次，这部分实现有一些 bug，当前还不能通过修改设置来实现缩进。要修复这个问题，可以使用下面的方法：
 

--- a/docs/FAQ/heading-various-format.md
+++ b/docs/FAQ/heading-various-format.md
@@ -13,7 +13,7 @@ tags: [heading, numbering]
     level: 1,
     {
       counter("chapter").step()
-      counter("chapter").display("第一章")
+      context counter("chapter").display("第一章")
       h(0.3em)
       title
     },
@@ -25,7 +25,7 @@ tags: [heading, numbering]
     level: 1,
     {
       counter("subject").step()
-      counter("subject").display("专题一")
+      context counter("subject").display("专题一")
       h(0.3em)
       title
     },

--- a/docs/FAQ/lang-fonts.md
+++ b/docs/FAQ/lang-fonts.md
@@ -3,26 +3,34 @@ tags: [font, chinese]
 ---
 # 中英文如何使用不同的字体？
 
+::: tip ✅ Typst 0.13 已改进
+[#5305](https://github.com/typst/typst/pull/5305) 增加了 `covers` 选项，请这样设置：
+
+```typst
+#set text(font: (
+  (name: "Times New Roman", covers: "latin-in-cjk"),
+  "SimSun"
+))
+分别设置“中文”和English字体
+```
+:::
+
+如果你使用旧版本，请使用以下旧方案。
+
 设置字体可以使用一个列表，Typst 会按照列表中的顺序依次尝试使用字体。因此只需把英文字体放在中文字体前面即可。例如：
 
 ```typst
 #set text(font: ("Times New Roman", "SimSun"))
-
-Typst 你好
-
+分别设置“中文”和English字体
 ```
 
 当然，这种方式严格来说并不是“中英文使用不同的字体”，但是 99% 的情况下已经够用了。
 
-<details>
-<summary>如果你是剩下的 1%</summary>
-
-如果你发现了中文引号等标点不对劲，那么你可以用这个修复 `#show regex("[“‘’”]|——|……"): set text(font: "SimSun")`，并期待 Typst 更新。
+::: details 如果你是剩下的 1%
+如果你发现了中文引号等标点不对劲，那么你可以用这个修复 `#show regex("[“‘’”]|——|……"): set text(font: "SimSun")`。
 
 如果你还需要对中文字体进行特殊处理，例如只缩小中文字体的大小，可以考虑用正则表达式[匹配 script](https://www.unicode.org/reports/tr18/tr18-21.html#Script_Property) 进行 hack：`#show regex("\p{sc=Hani}+"): set text(size: 0.8em)`。
 
-Tracking Issues：
+Tracking Issue：
 - 按语言配置字体 https://github.com/typst/typst/issues/794
-- 汉字默认等宽字体 https://github.com/typst/typst/issues/3385
-
-</details>
+:::


### PR DESCRIPTION
- 修复 typst v0.12.0 的警告（#46 和 [indenta](https://typst.app/universe/package/indenta) 除外）
- 更新 typst v0.13.0-rc1 情况

可以搜索`stdin`查找所有日志。
