### PR TITLE
feat: 显示最后更新时的 typst 版本

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -4,6 +4,7 @@ import DefaultTheme from 'vitepress/theme';
 import { computed } from 'vue';
 import { Waline } from '@waline/client/component';
 import { makeTags } from './utils';
+import { getTypstVersion } from './typst_version'
 import '@waline/client/style';
 
 const { Layout } = DefaultTheme;
@@ -14,6 +15,8 @@ const serverURL = 'https://typst-waline.vercel.app/';
 const path = computed(() => useRoute().path);
 
 const tags = computed(() => makeTags(data.frontmatter.value.tags));
+
+const typstVersion = computed(() => getTypstVersion(new Date(data.page.value.lastUpdated)));
 </script>
 
 <style>
@@ -46,6 +49,13 @@ const tags = computed(() => makeTags(data.frontmatter.value.tags));
           </a>
         </div>
       </div>
+    </template>
+    <template #doc-footer-before>
+      <!-- 与 <VPDocFooterLastUpdated> 并列 -->
+      <p
+        class="text-align-right"
+        style="font-size: 14px; font-weight: 500; color: var(--vp-c-text-2);"
+      >更新时针对 typst {{ typstVersion.version }}<span v-if="typstVersion.latest">（最新版）</span></p>
     </template>
     <template #doc-after>
       <Waline :serverURL="serverURL" :path="path" />

--- a/docs/.vitepress/theme/typst_version.ts
+++ b/docs/.vitepress/theme/typst_version.ts
@@ -1,0 +1,58 @@
+/**
+ * typst 的发布历史
+ *
+ * 最近的在前。
+ */
+const typst_history: {
+  publishedAt: Date;
+  tagName: string;
+}[] = [
+  // 更新方法：
+  // gh release --repo typst/typst list --json 'tagName,publishedAt' --exclude-pre-releases --limit 5
+  { "publishedAt": "2025-02-19T16:25:41Z", "tagName": "v0.13.0" },
+  { "publishedAt": "2024-10-18T21:41:48Z", "tagName": "v0.12.0" },
+  { "publishedAt": "2024-05-17T15:33:15Z", "tagName": "v0.11.1" },
+  { "publishedAt": "2024-03-15T18:05:50Z", "tagName": "v0.11.0" },
+  { "publishedAt": "2023-12-04T15:51:31Z", "tagName": "v0.10.0" },
+  { "publishedAt": "2023-10-31T01:32:16Z", "tagName": "v0.9.0" },
+  { "publishedAt": "2023-09-13T15:45:00Z", "tagName": "v0.8.0" },
+  { "publishedAt": "2023-08-07T16:20:37Z", "tagName": "v0.7.0" },
+  { "publishedAt": "2023-06-30T15:04:25Z", "tagName": "v0.6.0" },
+  { "publishedAt": "2023-06-09T14:55:29Z", "tagName": "v0.5.0" },
+  { "publishedAt": "2023-05-20T20:40:20Z", "tagName": "v0.4.0" },
+  { "publishedAt": "2023-04-26T14:20:47Z", "tagName": "v0.3.0" },
+  { "publishedAt": "2023-04-11T20:39:55Z", "tagName": "v0.2.0" },
+  { "publishedAt": "2023-04-04T23:46:28Z", "tagName": "v0.1.0" },
+].map(
+  ({ publishedAt, tagName }) => ({
+    publishedAt: new Date(publishedAt),
+    tagName,
+  }),
+);
+
+type TypstVersion = {
+  /** typst 版本，以“v”开头 */
+  version: string;
+  /** 是否是最新版 */
+  latest: boolean;
+};
+
+/**
+ * 获取`date`时的 typst 版本
+ * @param date
+ * @returns 版本信息
+ * @throws 若彼时尚未发布任何版本，会报错
+ */
+export function getTypstVersion(date: Date): TypstVersion {
+  const found = typst_history.find(
+    ({ publishedAt }) => publishedAt < date,
+  );
+  if (!found) {
+    throw new Error(`failed to find any typst version before ${date}`);
+  }
+
+  return {
+    version: found.tagName,
+    latest: found.tagName == typst_history[0].tagName,
+  };
+}


### PR DESCRIPTION
- 把 typst 的发布历史保存了到代码中。

  （并未每次访问 GitHub API，因为那有频率限制。）

  以后每次 typst 发布新版本后，需要手动更新`docs/.vitepress/theme/typst_version.ts`（更新方法见注释）；不过本来也需要适配新版本，应该工作量增加得不多？

- 显示样式参考了`<VPDocFooterLastUpdated>`

  https://github.com/vuejs/vitepress/blob/52c2aa178d4b3fa98b863cf28f0ccf6d2aabcd93/src/client/theme-default/components/VPDocFooterLastUpdated.vue#L38-L40

  关于如何实现，人工智能还给出了扩展 markdown-it、VitePress alias、扩展 vite 等方案。目前的做法是改动最少的。
