### PR TITLE
补充 chinese-remove-space 的副作用

### DIFF
--- a/docs/FAQ/chinese-remove-space.md
+++ b/docs/FAQ/chinese-remove-space.md
@@ -7,9 +7,9 @@ tags: [layout, text]
 0.12 可以玩 `regex` 魔法了，`regex` 现在可以跨不同的 `text`
 
 ```typst
-✅测试一下，效果怎么样。
+✓ 测试一下，效果怎么样。
 
-😥测试一下，
+✗ 测试一下，
 效果怎么样。
 
 // https://www.w3.org/TR/clreq/#table_of_punctuation_marks
@@ -19,7 +19,7 @@ tags: [layout, text]
   a + b
 }
 
-✅测试一下，
+✓ 测试一下，
 效果怎么样。
 ```
 
@@ -31,9 +31,9 @@ tags: [layout, text]
 #set page(width: auto, height: auto, margin: 1em)
 #set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
 
-✅“七斤嫂，你‘恨棒打人’。……”
+✓“七斤嫂，你‘恨棒打人’。……”
 
-😥“七斤嫂，你‘恨棒打人’。
+✗“七斤嫂，你‘恨棒打人’。
 ……”
 
 #show regex("[。] [……]"): it => {
@@ -41,7 +41,7 @@ tags: [layout, text]
   a + b
 }
 
-😥“七斤嫂，你‘恨棒打人’。
+✗“七斤嫂，你‘恨棒打人’。
 ……”
 ```
 

--- a/docs/FAQ/chinese-remove-space.md
+++ b/docs/FAQ/chinese-remove-space.md
@@ -7,10 +7,10 @@ tags: [layout, text]
 0.12 可以玩 `regex` 魔法了，`regex` 现在可以跨不同的 `text`
 
 ```typst
-测试一下，效果怎么样。（✓）
+测试一下，效果怎么样。✓
 
 测试一下，
-效果怎么样。（✗）
+效果怎么样。✗
 
 // https://www.w3.org/TR/clreq/#table_of_punctuation_marks
 #let han-or-punct = "[-\p{sc=Hani}。．，、：；！‼？⁇⸺——……⋯⋯～–—·・‧/／「」『』“”‘’（）《》〈〉【】〖〗〔〕［］｛｝＿﹏●•]"
@@ -20,7 +20,7 @@ tags: [layout, text]
 }
 
 测试一下，
-效果怎么样。（✓）
+效果怎么样。✓
 ```
 
 ::: details 微小副作用
@@ -31,18 +31,18 @@ tags: [layout, text]
 #set page(width: auto, height: auto, margin: 1em)
 #set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
 
-“七斤嫂，你‘恨棒打人’。……”（✓）
+“七斤嫂，你‘恨棒打人’。……”✓
 
-“七斤嫂，你‘恨棒打人’。（✗）
-……”
+“七斤嫂，你‘恨棒打人’。
+……”✗
 
 #show regex("[。] [……]"): it => {
   let (a, _, b) = it.text.clusters()
   a + b
 }
 
-“七斤嫂，你‘恨棒打人’。（✗）
-……”
+“七斤嫂，你‘恨棒打人’。
+……”✗
 ```
 
 相关 issue：[Ignore linebreaks between CJK characters in source code · #792](https://github.com/typst/typst/issues/792)

--- a/docs/FAQ/chinese-remove-space.md
+++ b/docs/FAQ/chinese-remove-space.md
@@ -7,14 +7,43 @@ tags: [layout, text]
 0.12 可以玩 `regex` 魔法了，`regex` 现在可以跨不同的 `text`
 
 ```typst
-测试一下，
+✅测试一下，效果怎么样。
+
+😥测试一下，
 效果怎么样。
 
-#show regex("[\p{sc=Hani} 。 ； ， ： “ ”（ ） 、 ？ 《 》] [\p{sc=Hani} 。 ； ， ： “ ”（ ） 、 ？ 《 》]"): it => {
+// https://www.w3.org/TR/clreq/#table_of_punctuation_marks
+#let han-or-punct = "[-\p{sc=Hani}。．，、：；！‼？⁇⸺——……⋯⋯～–—·・‧/／「」『』“”‘’（）《》〈〉【】〖〗〔〕［］｛｝＿﹏●•]"
+#show regex(han-or-punct + " " + han-or-punct): it => {
   let (a, _, b) = it.text.clusters()
   a + b
 }
 
-测试一下，
+✅测试一下，
 效果怎么样。
 ```
+
+::: details 微小副作用
+
+在整个正则表达式匹配的边界，标点宽度会有问题。
+
+```typst
+#set page(width: auto, height: auto, margin: 1em)
+#set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
+
+✅“七斤嫂，你‘恨棒打人’。……”
+
+😥“七斤嫂，你‘恨棒打人’。
+……”
+
+#show regex("[。] [……]"): it => {
+  let (a, _, b) = it.text.clusters()
+  a + b
+}
+
+😥“七斤嫂，你‘恨棒打人’。
+……”
+```
+
+相关 issue：[Ignore linebreaks between CJK characters in source code · #792](https://github.com/typst/typst/issues/792)
+:::

--- a/docs/FAQ/chinese-remove-space.md
+++ b/docs/FAQ/chinese-remove-space.md
@@ -7,10 +7,10 @@ tags: [layout, text]
 0.12 可以玩 `regex` 魔法了，`regex` 现在可以跨不同的 `text`
 
 ```typst
-✓ 测试一下，效果怎么样。
+测试一下，效果怎么样。（✓）
 
-✗ 测试一下，
-效果怎么样。
+测试一下，
+效果怎么样。（✗）
 
 // https://www.w3.org/TR/clreq/#table_of_punctuation_marks
 #let han-or-punct = "[-\p{sc=Hani}。．，、：；！‼？⁇⸺——……⋯⋯～–—·・‧/／「」『』“”‘’（）《》〈〉【】〖〗〔〕［］｛｝＿﹏●•]"
@@ -19,8 +19,8 @@ tags: [layout, text]
   a + b
 }
 
-✓ 测试一下，
-效果怎么样。
+测试一下，
+效果怎么样。（✓）
 ```
 
 ::: details 微小副作用
@@ -31,9 +31,9 @@ tags: [layout, text]
 #set page(width: auto, height: auto, margin: 1em)
 #set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
 
-✓“七斤嫂，你‘恨棒打人’。……”
+“七斤嫂，你‘恨棒打人’。……”（✓）
 
-✗“七斤嫂，你‘恨棒打人’。
+“七斤嫂，你‘恨棒打人’。（✗）
 ……”
 
 #show regex("[。] [……]"): it => {
@@ -41,7 +41,7 @@ tags: [layout, text]
   a + b
 }
 
-✗“七斤嫂，你‘恨棒打人’。
+“七斤嫂，你‘恨棒打人’。（✗）
 ……”
 ```
 


### PR DESCRIPTION
副作用里的例子之所以设置字体，是因为在渲染默认设置下，引号宽度本来就不对。
