### PR TITLE
改进缩进相关的链接

### DIFF
--- a/docs/FAQ/block-equation-in-paragraph.md
+++ b/docs/FAQ/block-equation-in-paragraph.md
@@ -1,11 +1,11 @@
 ---
-tags: [math,layout]
+tags: [math, layout]
 ---
-# 如何在段落内加入行间数学公式以避免首行缩进？
+# 如何避免公式、图表等块元素的下一行缩进？
 
-更详细问题的描述：在段落中加入行间数学公式，总会在后面加入一个新段落，导致出现段落首行缩进。我们希望在创建行间数学公式，且公式后没有空行时，不出现新段落和首行缩进。https://github.com/typst/typst/issues/3206
+在段落中加入行间数学公式，总会在后面加入一个新段落，导致出现段落首行缩进。我们希望在创建行间数学公式，且公式后没有空行时，不出现新段落和首行缩进。
 
-1. 用 `#box()` 将行间数学公式包住，且不能有空行。
+用 `#box()` 将行间数学公式包住，且不能有空行。
 
 ```typst
 #set page(width: 30em, height: auto)
@@ -27,12 +27,12 @@ shows that the integral of $x + y$ is $z$.
 #set math.equation(numbering: "(1.1)")
 
 #lorem(10), for example,
-
 $ integral x + y = z $
-
 shows that the integral of $x + y$ is $z$.
 
 #lorem(20)
 ```
 
 对于 tight list 和 figure 来说也是同理。
+
+相关 issue：[Paragraph should be able to contain tight lists and block-level equations · #3206](https://github.com/typst/typst/issues/3206)

--- a/docs/FAQ/first-line-indent.md
+++ b/docs/FAQ/first-line-indent.md
@@ -4,7 +4,7 @@ tags: [layout]
 # 【已修复】为什么第一段没有缩进？
 
 ::: tip ✅ Typst 0.13 已修复
-[#5768](https://github.com/typst/typst/pull/5768) 增加了 `all` 选项，可以缩进所有段落了，但会在 `figure`、`equation` 等块元素后强行换行。
+[#5768](https://github.com/typst/typst/pull/5768) 增加了 `all` 选项，可以缩进所有段落了。
 
 ```typst
 #set par(first-line-indent: (amount: 2em, all: true))
@@ -15,6 +15,8 @@ tags: [layout]
 
 之后段落原本已缩进。
 ```
+
+不过，公式、图表等块元素等块元素后也强行缩进了，可[套`#box[…]`修复](./block-equation-in-paragraph.md)。
 :::
 
 首先，英文排版是这样的，LaTeX 默认第一段也是不缩进的。其次，这部分实现有一些 bug，当前还不能通过修改设置来实现缩进。要修复这个问题，可以使用下面的方法：


### PR DESCRIPTION
之前 #51 和 #53 两人没商量好。

- [如何避免公式、图表等块元素的下一行缩进？ | Typst 中文社区导航](https://deploy-preview-55--luxury-mochi-9269a9.netlify.app/FAQ/block-equation-in-paragraph.html)
- [【已修复】为什么第一段没有缩进？ | Typst 中文社区导航](https://deploy-preview-55--luxury-mochi-9269a9.netlify.app/FAQ/first-line-indent.html)
