### PR TITLE
feat: 以`-- `开头的行在显示时隐藏，在编译时保留

### DIFF
--- a/docs/.vitepress/typst_template.ts
+++ b/docs/.vitepress/typst_template.ts
@@ -1,0 +1,4 @@
+export default `
+#set page(height: 4cm, width: 6cm)
+#set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
+<<src>>`.trim();

--- a/docs/.vitepress/util.ts
+++ b/docs/.vitepress/util.ts
@@ -31,3 +31,13 @@ export function prettify(
   }
   return lines.map((l) => `${indent}${l}`).join('\n');
 }
+
+/**
+ * 若以`prefix`开头，删除之
+ */
+export function removePrefix(s: string, prefix: string): string {
+  if (s.startsWith(prefix)) {
+    return s.slice(prefix.length);
+  }
+  return s;
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -63,11 +63,30 @@ $ sum_(k=1)^n k = (n(n+1)) / 2 $
 
 注意：渲染器在将文档中的 typst 代码渲染成图片时会自动在前面插入这两行代码，避免生成的图片过大，改善阅读体验。因此需要较大的页面展示代码效果的时候记得手动设置页面尺寸。
 ```typst no-render
-#set page(height: 4cm, width: 6cm)
-#set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
+<!--@include: @/.vitepress/typst_template.ts{2,3} -->
 ```
 
-另外，如果问题已在新版 typst 修复或改进，可在标题开头添加`【已修复】`，并注明版本。
+对于设置页面这种与正文关系不大的代码，可于行首加`-- `，在渲染时隐藏。
+
+::: details 示例：隐藏代码
+
+`.md` 文件：
+
+```typst no-render
+-- #set page(width: auto, height: auto, margin: 1em)
+#lorem(1)
+```
+
+渲染结果：
+
+```typst
+-- #set page(width: auto, height: auto, margin: 1em)
+#lorem(1)
+```
+
+:::
+
+最后，如果问题已在新版 typst 修复或改进，可在标题开头添加`【已修复】`，并注明版本。
 
 ```md
 # 【已修复】……？

--- a/docs/FAQ/block-equation-in-paragraph.md
+++ b/docs/FAQ/block-equation-in-paragraph.md
@@ -8,9 +8,9 @@ tags: [math, layout]
 用 `#box()` 将行间数学公式包住，且不能有空行。
 
 ```typst
-#set page(width: 30em, height: auto)
+-- #set page(width: 30em, height: auto)
 #set par(first-line-indent: (amount: 2em, all: true))
-#set math.equation(numbering: "(1.1)")
+-- #set math.equation(numbering: "(1.1)")
 
 #lorem(10), for example,
 #box[$ integral x + y = z $]
@@ -22,15 +22,12 @@ shows that the integral of $x + y$ is $z$.
 对比
 
 ```typst
-#set page(width: 30em, height: auto)
-#set par(first-line-indent: (amount: 2em, all: true))
-#set math.equation(numbering: "(1.1)")
-
+-- #set page(width: 30em, height: auto)
+-- #set par(first-line-indent: (amount: 2em, all: true))
+-- #set math.equation(numbering: "(1.1)")
 #lorem(10), for example,
 $ integral x + y = z $
 shows that the integral of $x + y$ is $z$.
-
-#lorem(20)
 ```
 
 对于 tight list 和 figure 来说也是同理。

--- a/docs/FAQ/chinese-bold.md
+++ b/docs/FAQ/chinese-bold.md
@@ -6,15 +6,15 @@ tags: [chinese, text]
 这是因为你使用的中文字体没有粗体字形。我们常用的宋体、黑体、楷体等都没有粗体字形。推荐使用支持粗体的字体，例如使用思源宋体和思源黑体。
 
 ```typst
+-- #set page(height: auto, margin: 1em)
 #set text(font: ("Source Han Serif SC"))
-
 现在可以使用*粗体*了
-
 ```
 
 然而，某些场合可能必须使用宋体。Microsoft Word 通过给字体增加描边实现了“伪粗体”，若要实现与 Microsoft Word 同样的效果，可以使用 [`cuti` 包](https://typst.app/universe/package/cuti)：
 
 ```typst
+-- #set page(height: auto, margin: 1em)
 #import "@preview/cuti:0.2.1": show-cn-fakebold
 #show: show-cn-fakebold
 #set text(font: ("Times New Roman", "SimSun"))

--- a/docs/FAQ/chinese-remove-space.md
+++ b/docs/FAQ/chinese-remove-space.md
@@ -7,6 +7,7 @@ tags: [layout, text]
 0.12 可以玩 `regex` 魔法了，`regex` 现在可以跨不同的 `text`
 
 ```typst
+-- #set page(width: auto, height: auto, margin: 1em)
 测试一下，效果怎么样。✓
 
 测试一下，
@@ -28,9 +29,7 @@ tags: [layout, text]
 在整个正则表达式匹配的边界，标点宽度会有问题。
 
 ```typst
-#set page(width: auto, height: auto, margin: 1em)
-#set text(font: ((name: "New Computer Modern", covers: "latin-in-cjk"), "Source Han Serif SC"))
-
+-- #set page(width: auto, height: auto, margin: 1em)
 “七斤嫂，你‘恨棒打人’。……”✓
 
 “七斤嫂，你‘恨棒打人’。

--- a/docs/FAQ/chinese-skew.md
+++ b/docs/FAQ/chinese-skew.md
@@ -9,7 +9,8 @@ tags: [chinese, text]
 一般使用其他字体（如楷体）代替斜体：
 
 ```typst
-#let 西文字体 = "Libertinus Serif"
+-- #set page(height: auto, margin: 1em)
+-- #let 西文字体 = (name: "Libertinus Serif", covers: "latin-in-cjk")
 #show emph: text.with(font: (西文字体, "Kaiti"))
 孔乙己_上大人_
 ```
@@ -18,6 +19,7 @@ tags: [chinese, text]
 
 伪斜体也可使用[`skew`函数](https://typst.app/docs/reference/layout/skew/)：
 ```typst
+-- #set page(height: auto, margin: 1em)
 #skew(ax: -12deg)[111]111
 ```
 但是针对一大段效果并不好。

--- a/docs/FAQ/chinese-space.md
+++ b/docs/FAQ/chinese-space.md
@@ -10,6 +10,7 @@ tags: [chinese, bug, text]
 临时修复方法：
 
 ```typst
+-- #set page(height: auto, margin: 1em)
 #show math.equation.where(block: false): it => h(0.25em, weak: true) + it + h(0.25em, weak: true)
 汉字$A$汉字
 ```

--- a/docs/FAQ/dcases.md
+++ b/docs/FAQ/dcases.md
@@ -4,7 +4,7 @@ tags: [math]
 # 如何让 cases 里面的分数/公式显示成 display 形式？
 
 ```typst
-#set page(height: auto)
+-- #set page(height: auto)
 #import "@preview/physica:0.9.3": *
 #let dcases(..args) = math.cases(..args.pos().map(math.display))
 $

--- a/docs/FAQ/equation-chinese-font.md
+++ b/docs/FAQ/equation-chinese-font.md
@@ -7,6 +7,7 @@ tags: [math, equation, text]
 使用 `regex("\p{script=Han}")` 匹配中文，不太优雅，但是目前没有更好的方法。
 
 ```typst
+-- #set page(height: auto, margin: 1em)
 #show math.equation: it => {
   show regex("\p{script=Han}"): set text(font: "Source Han Serif SC")
   it

--- a/docs/FAQ/equation_linebreak_superscript.md
+++ b/docs/FAQ/equation_linebreak_superscript.md
@@ -7,8 +7,7 @@ tags: [math, code, layout]
 可以使用宽度为 0 的 `box` 来提高上标的位置凑合一下，像下面第 3 个公式一样。
 
 ```typst
-#set page(height: auto)
-
+-- #set page(height: auto)
 $ [sum a / b + \ c]^2 $
 
 $ [sum a / b + \ c]""^2 $

--- a/docs/FAQ/lang-fonts.md
+++ b/docs/FAQ/lang-fonts.md
@@ -7,6 +7,7 @@ tags: [font, chinese, text]
 [#5305](https://github.com/typst/typst/pull/5305) 增加了 `covers` 选项，请这样设置：
 
 ```typst
+-- #set page(width: 18em, height: auto, margin: 1em)
 #set text(font: (
   (name: "Times New Roman", covers: "latin-in-cjk"),
   "SimSun"
@@ -20,6 +21,7 @@ tags: [font, chinese, text]
 设置字体可以使用一个列表，Typst 会按照列表中的顺序依次尝试使用字体。因此只需把英文字体放在中文字体前面即可。例如：
 
 ```typst
+-- #set page(width: 18em, height: auto, margin: 1em)
 #set text(font: ("Times New Roman", "SimSun"))
 分别设置“中文”和English字体
 ```

--- a/docs/FAQ/rounded-corner-table.md
+++ b/docs/FAQ/rounded-corner-table.md
@@ -7,7 +7,7 @@ tags: [table]
 使用 `block` 提供的 `radius` 即可实现圆角，结合 `clip` 参数可以去除不需要的部分。为了实现样式的统一 `stroke` 需要提前定义。
 
 ```typst
-#set page(width: 10cm, height: auto)
+-- #set page(width: 10cm, height: auto)
 #let stroke = stroke(2pt + gradient.linear(..color.map.plasma))
 #show table: it => block(stroke: stroke, radius: 2em, clip: true, it)
 

--- a/docs/FAQ/sub-figure.md
+++ b/docs/FAQ/sub-figure.md
@@ -9,7 +9,7 @@ tags: [layout, figure]
 这个编号不需要经常修改，因此使用 `grid` 布局，然后手动编号即可。
 
 ```typst
-#set page(width: 12cm, height: auto)
+-- #set page(width: 12cm, height: auto)
 #figure(grid(columns: 2, gutter: 1em,
   figure(rect(), numbering: none, caption: [a) demo1]),
   figure(rect(), numbering: none, caption: [b) demo2]),
@@ -23,7 +23,7 @@ tags: [layout, figure]
 https://typst.app/universe/package/subpar/
 
 ```typst
-#set page(width: 12cm, height: auto)
+-- #set page(width: 12cm, height: auto)
 #import "@preview/subpar:0.2.1": grid as subfigure
 #subfigure(
   align:center,
@@ -46,7 +46,7 @@ https://typst.app/universe/package/subpar/
 **情况 1：** `i-figured `会忽略 `figure` 的 `numbering`，导致出现计数错误
 
 ```typst
-#set page(width: 12cm, height: auto)
+-- #set page(width: 12cm, height: auto)
 #import "@preview/i-figured:0.2.4"
 #show figure: i-figured.show-figure
 #figure(grid(columns: 2, gutter: 1em,
@@ -58,7 +58,7 @@ https://typst.app/universe/package/subpar/
 **情况 2**：`i-figured` 会对 `subpar` 中超图进行冲突计数
 
 ```typst
-#set page(width: 12cm, height: auto)
+-- #set page(width: 12cm, height: auto)
 #import "@preview/i-figured:0.2.4"
 #show figure: i-figured.show-figure
 #import "@preview/subpar:0.2.1": grid as subfigure
@@ -81,7 +81,7 @@ https://typst.app/universe/package/subpar/
 **正确用法：** 使用 `subpar` 实现子图超图功能，自行实现编号规则
 
 ```typst
-#set page(width: 20cm, height: auto)
+-- #set page(width: 20cm, height: auto)
 // Synopsis:
 // - adding contextual numbering like chapter-relative numbering preserves the correct subfigure
 //   numbering and supplements

--- a/docs/FAQ/wave-underline.md
+++ b/docs/FAQ/wave-underline.md
@@ -4,6 +4,7 @@ tags: [text]
 # 如何实现波浪线下划线？
 
 ```typst
+-- #set page(height: auto, margin: 1em)
 #let pat = tiling(size: (4pt, 3pt), curve(
   stroke: blue + 0.5pt,
   curve.move((0%, 10%)),

--- a/docs/word.md
+++ b/docs/word.md
@@ -202,8 +202,8 @@ This is a 中英文混排段落，如果 not 使用 `justify` 参数，将会默
 在 Typst 中，行距和段距分别由 `par` 的 `leading` 和 `spacing` 参数控制。行距是指行与行之间的距离，段距是指段与段之间的距离。如图所示。
 
 ```typst
-#set page(height: 6cm, width: 10cm)
-#let marker(body, height)=box(place(box(height: height, width: 2pt, stroke: (rest: 1pt+red, left: none), place(dx: 4pt, text(8pt, red, body)))))
+-- #set page(height: 6cm, width: 10cm)
+#let marker(body, height) = box(place(box(height: height, width: 2pt, stroke: (rest: 1pt+red, left: none), place(dx: 4pt, text(8pt, red, body)))))
 
 #set par(leading: 0.6em, spacing: 1em)
 
@@ -378,7 +378,7 @@ Typst 的标题编号是自动的，可以通过修改 `heading` 的 `numbering`
 Typst 的数学公式用一对 `$` 包裹。当 `$` 内侧有空白（空格或换行符）时为行间公式（e.g.，`$ a $`），否则为行内公式。
 
 ```typst
-#set page(height: auto)
+-- #set page(height: auto)
 行内公式：$(a+b)^2 = a^2 + 2 a b + b^2$
 
 公式块：
@@ -421,7 +421,7 @@ $
 - 群友科技 [zebraw](https://typst.app/universe/package/zebraw)
 
 ````typst
-#set page(paper: "a4", height: auto, margin: 1cm)
+-- #set page(paper: "a4", height: auto, margin: 1cm)
 #import "@preview/zebraw:0.3.0": *
 #show: zebraw
 #zebraw(
@@ -515,7 +515,7 @@ Typst 使用 `#bibliography` 命令来插入参考文献。在文中引用参考
 使用 `#footnote` 命令来插入脚注。
 
 ````typst
-#set page(height: auto)
+-- #set page(height: auto)
 在任意地方使用 ```typ #footnote``` 来插入一个脚注。比如这里#footnote[这个地方就是一个脚注]就是一个脚注。脚注会#footnote[自动编号]自动编号。
 ````
 


### PR DESCRIPTION
设计参考了 [rustdoc](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#hiding-portions-of-the-example)。

考虑到也许有从`*.md`直接复制代码调试的需求，并未采用 rustdoc 规定的`# `或 typst 的注释`// `，而用 lua 的注释`-- `。这样原始 typst 代码仍然合法；而且`-- `一般会编译成单个字符`–`（U+2013 EN DASH），结果接近原意。

到底是否采用这种方案，可以再商榷。
