### PR TITLE
补充 ref-superscript

### DIFF
--- a/docs/FAQ/ref-superscript.md
+++ b/docs/FAQ/ref-superscript.md
@@ -2,19 +2,26 @@
 tags: [bib, ref]
 ---
 
-# 如何让参考文献引用的上标和非上标形式共存？
+# 引用参考文献时，如何共存上标和非上标形式？
+
+按以下方法设置后，普通`@key`上标，`#parencite(<key>)`非上标。
+
+具体方法取决于引用的默认样式是否上标。
+
+## 若样式默认非上标（如`ieee`）
 
 ```typst
-#show ref: super
-#let plain-ref(label) = {
+-- #set page(height: auto)
+#show cite: super
+#let parencite(label) = {
   show super: it => it.body
-  ref(label)
+  [文献~] + ref(label)
 }
 
-你说得对，中间见文献#plain-ref(<bib1>)，后面忘了@bib1
+你说得对，中间见#parencite(<key>)，后面忘了@key。
 
 #bibliography(
-  bytes("@phdthesis{bib1,
+  bytes("@phdthesis{key,
     type = {{超高校级学位论文}},
     title = {{基于图书室的笔记本电脑的 Alter Ego 系统}},
     author = {不二咲, 千尋},
@@ -23,6 +30,28 @@ tags: [bib, ref]
     school = {私立希望ヶ峰学園},
     publisher = {私立希望ヶ峰学園},
   }"),
+  style: "ieee",
 )
+```
 
+## 若样式默认上标（如`gb-7714-2015-numeric`）
+
+```typst
+-- #set page(height: auto)
+#let parencite(key, ..args) = [文献~#cite(key, style: "ieee", ..args)]
+
+你说得对，中间见#parencite(<key>)，后面忘了@key。
+
+#bibliography(
+  bytes("@phdthesis{key,
+    type = {{超高校级学位论文}},
+    title = {{基于图书室的笔记本电脑的 Alter Ego 系统}},
+    author = {不二咲, 千尋},
+    year = {2010},
+    address = {某地},
+    school = {私立希望ヶ峰学園},
+    publisher = {私立希望ヶ峰学園},
+  }"),
+  style: "gb-7714-2015-numeric",
+)
 ```


### PR DESCRIPTION
Continues #69
https://deploy-preview-70--luxury-mochi-9269a9.netlify.app/FAQ/ref-superscript.html

如果`cite`默认上标，那么之前版本会给出：
![Image](https://github.com/user-attachments/assets/91e1cf20-055c-474b-ae44-ae3bf138276f)

---

@jingkaimori 我把你的`show ref`改成了`show cite`，否则其它`ref`也上标了。不知原来是否有特殊用意？

```typst
#set heading(numbering: "1")
= 章节标题 <sec>

否则@sec 这样也上标了。
```

---

`parencite`的名字是 LaTeX 遗产／遗毒，比较长；不过就我以往体验来说，非上标形式的频率不高，打起来还能接受。有更好名字的话可以换。
![图片](https://github.com/user-attachments/assets/0ccb6e60-e245-44b5-a74a-d1fa93e6b818)
