### PR TITLE
更新公式中文字体设置的FAQ

### DIFF
--- a/docs/FAQ/equation-chinese-font.md
+++ b/docs/FAQ/equation-chinese-font.md
@@ -1,10 +1,32 @@
 ---
-tags: [math, equation, text]
+tags: [font, math, equation, text]
 ---
 
 # 如何修改公式里的中文字体？
 
-使用 `regex("\p{script=Han}")` 匹配中文，不太优雅，但是目前没有更好的方法。
+::: tip ✅ Typst 0.13 已改进
+[#5305](https://github.com/typst/typst/pull/5305) 目前可以对不同字符分别设置不同的字体。
+
+配置正文字体后，请继续设置数学公式的字体：
+
+```typst no-render
+#show math.equation : set text(font: (
+  (name: "Noto Sans CJK SC", covers: regex("\p{script=Han}")),
+  "New Computer Modern Math",
+))
+
+$ f(x) #[原神] $
+```
+
+- 「New Computer Modern Math」是数学字体，负责 `123`、`abc`、`,"!、{}()` 等
+- 「Noto Sans CJK SC」是 CJK 字体，负责汉字和`，“”！`等
+
+此外，请**不要**设置 `#show raw: set text(fallback: false)`。
+:::
+
+如果你使用旧版本，请使用以下旧方案。
+
+使用 `regex("\p{script=Han}")` 匹配中文。
 
 ```typst
 -- #set page(height: auto, margin: 1em)

--- a/docs/FAQ/equation-chinese-font.md
+++ b/docs/FAQ/equation-chinese-font.md
@@ -21,7 +21,7 @@ $ f(x) #[原神] $
 - 「New Computer Modern Math」是数学字体，负责 `123`、`abc`、`,"!、{}()` 等
 - 「Noto Sans CJK SC」是 CJK 字体，负责汉字和`，“”！`等
 
-此外，请**不要**设置 `#show raw: set text(fallback: false)`。
+此外，请**不要**设置 `#show math.equation: set text(fallback: false)`。
 :::
 
 如果你使用旧版本，请使用以下旧方案。


### PR DESCRIPTION
为什么不用"latin-in-cjk"，仍然用正则表达式？中文字体`Noto Sans CJK SC`不能作为数学公式字体