### PR TITLE
docs: 更正underline用zwj占位的过时/错误方案

### DIFF
--- a/docs/FAQ/underline-not-display.md
+++ b/docs/FAQ/underline-not-display.md
@@ -11,7 +11,7 @@ tags: [text]
 - 空空#underline[     ]如也
 ```
 
-## 若坚持用`underline`
+## 若坚持用 `underline`
 
 请换用字符串占位。
 
@@ -23,7 +23,7 @@ tags: [text]
 - 空空#underline("\u{3000}" * 2)如也
 ```
 
-## 换用`box`
+## 换用 `box`
 
 也可换用[`box`](https://typst.app/docs/reference/layout/box/#parameters-baseline)，直接指定长度：
 
@@ -32,12 +32,20 @@ tags: [text]
 空空#box(width: 2em, stroke: (bottom: 0.5pt))如也
 ```
 
-若之前用`underline(offset: …)`调整了下划线位置，现在可用`box(outset: …)`替代：
+若之前用 `underline(offset: …)` 调整了下划线位置，现在可用 `box(outset: …)` 替代：
 
 ```typst
 -- #set page(height: auto, width: auto, margin: 1em)
 #let uline(width) = box(width: width, stroke: (bottom: 0.5pt), outset: (bottom: 2pt))
 空空#uline(2em)如也
+```
+
+用 `box` 的优点是方便填入内容，例如
+
+```typst
+-- #set page(height: auto, width: auto, margin: 1em)
+#let uline(width, body) = box(align(center, body), width: width, stroke: (bottom: 0.5pt), outset: (bottom: 2pt))
+日期：#uline(3em)[2025]年#uline(1em)[6]月
 ```
 
 ::: details 番外


### PR DESCRIPTION
刚才有人问了这个问题，原来说用zwj，但无效啊。不清楚是新版 typst 更新了，还是原来就不对。

https://typst-doc-cn.github.io/guide/FAQ/underline-not-display.html
https://deploy-preview-77--luxury-mochi-9269a9.netlify.app/FAQ/underline-not-display.html