### PR TITLE
docs: 更正 mathcal 和 mathscr 相关信息

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress';
+import footnote from 'markdown-it-footnote';
 import UnoCSS from 'unocss/vite';
 import TypstRender from './typst_render';
 
@@ -15,6 +16,7 @@ export default defineConfig({
       dark: 'github-dark',
     },
     config: (md) => {
+      md.use(footnote);
       md.use(TypstRender);
     },
   },

--- a/docs/FAQ/mathcal_font.md
+++ b/docs/FAQ/mathcal_font.md
@@ -1,28 +1,17 @@
 ---
-tags: [equation, font]
+tags: [math, font]
 ---
 
 # 怎么把 cal 字体变成 LaTeX 里 mathcal 默认的那种？
 
-## 标准办法
+Typst 中数学字体默认是 New Computer Modern Math，与 LaTeX 中默认[^unicode-math]的 Computer Modern Math 略有不同。
 
-```typst
--- #set page(height: auto)
-#let scr(it) = text(
-  features: ("ss01",),
-  box($cal(it)$),
-)
+[^unicode-math]: 此处指不使用 unicode-math 时的默认数学字体；若使用 unicode-math，默认字体是 New Computer Modern Math，Typst 效果与之相同。
 
-We establish $cal(P) != scr(P)$.
-```
+若想使用 LaTeX 默认的`\mathcal`花体，需要更换字体。
 
-来源：[`cal` - Variants Functions – Typst Documentation](https://typst.app/docs/reference/math/variants#functions-cal)。
-
-## 另法
-
-字体不一样，换个字体即可。LaTeX 用的是 Computer Modern Math，mathcal 字体所在的字体文件名字通常是 `cmsy10.pfm`，你可以手动把它转换成 ttf 格式，但是没必要。
-
-另一种获得这个字体的方法是，如果你电脑上安装了 python 的 matplotlib 包，那么你可以在 `Lib/site-packages/matplotlib/mpl-data/fonts/ttf` 目录中找到 `cmsy10.ttf`，使用这个文件即可。
+1. 从 matplotlib 的`mpl-data/fonts/ttf/`文件夹[下载`cmsy10.ttf`](https://github.com/matplotlib/matplotlib/blob/be68dfecf9d26ac1a8e1e30a0de6171ecf174cd5/lib/matplotlib/mpl-data/fonts/ttf/cmsy10.ttf)
+2. 设置`font: "cmsy10"`
 
 ```typst no-render
 $ cal(K M Z) $
@@ -31,3 +20,14 @@ $ cal(K M Z) $
 ```
 
 ![image](https://github.com/user-attachments/assets/481908d4-6163-425b-9296-617eef98338f)
+
+::: details 为何出现 matplotlib？
+
+Computer Modern Math 早于 OpenType 技术标准，通常以 Type 1 字体形式存在，如`cmsy10.pfm`。
+
+今天很多软件都不支持`*.pfm`。matplotlib 开发者将它转换成了`cmsy10.ttf`，可供 Typst 等软件使用。
+
+:::
+
+
+另外，LaTeX 中有 calligraphic 和 script 两种花体，后者请参考[如何实现`\mathscr`的花体符号](./symbol-mathscr.md)。

--- a/docs/FAQ/symbol-mathscr.md
+++ b/docs/FAQ/symbol-mathscr.md
@@ -1,9 +1,25 @@
 ---
-tags: [math]
+tags: [math, font]
 ---
 # 如何实现 mathscr 的花体符号？
 
-群友提问：话说 typst 未来可以支持 LaTeX 的一些数学字体，比如`\mathscr`的花体，感觉确实帅
+可用如下办法实现 LaTeX 的`\mathscr`花体。
+
+## 局部使用
+
+```typst
+-- #set page(height: auto)
+#let scr(it) = text(
+  stylistic-set: 1,
+  box($cal(it)$),
+)
+
+We establish $cal(P) != scr(P)$.
+```
+
+来源：[`cal` - Variants Functions – Typst Documentation](https://typst.app/docs/reference/math/variants#functions-cal)。
+
+## 全局设置
 
 ```typst
 #set text(stylistic-set: 1)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     }
   },
   "dependencies": {
-    "markdown-it": "^14.1.0"
+    "markdown-it": "^14.1.0",
+    "markdown-it-footnote": "^4.0.0"
   },
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.0
+      markdown-it-footnote:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@types/markdown-it':
         specifier: ^14.1.2
@@ -510,51 +513,61 @@ packages:
     resolution: {integrity: sha512-3pA7xecItbgOs1A5H58dDvOUEboG5UfpTq3WzAdF54acBbUM+olDJAPkgj1GRJ4ZqE12DZ9/hNS2QZk166v92A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.32.0':
     resolution: {integrity: sha512-Y7XUZEVISGyge51QbYyYAEHwpGgmRrAxQXO3siyYo2kmaj72USSG8LtlQQgAtlGfxYiOwu+2BdbPjzEpcOpRmQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.32.0':
     resolution: {integrity: sha512-r7/OTF5MqeBrZo5omPXcTnjvv1GsrdH8a8RerARvDFiDwFpDVDnJyByYM/nX+mvks8XXsgPUxkwe/ltaX2VH7w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.32.0':
     resolution: {integrity: sha512-HJbifC9vex9NqnlodV2BHVFNuzKL5OnsV2dvTw6e1dpZKkNjPG6WUq+nhEYV6Hv2Bv++BXkwcyoGlXnPrjAKXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.32.0':
     resolution: {integrity: sha512-VAEzZTD63YglFlWwRj3taofmkV1V3xhebDXffon7msNz4b14xKsz7utO6F8F4cqt8K/ktTl9rm88yryvDpsfOw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.32.0':
     resolution: {integrity: sha512-Sts5DST1jXAc9YH/iik1C9QRsLcCoOScf3dfbY5i4kH9RJpKxiTBXqm7qU5O6zTXBTEZry69bGszr3SMgYmMcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.32.0':
     resolution: {integrity: sha512-qhlXeV9AqxIyY9/R1h1hBD6eMvQCO34ZmdYvry/K+/MBs6d1nRFLm6BOiITLVI+nFAAB9kUB6sdJRKyVHXnqZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.32.0':
     resolution: {integrity: sha512-8ZGN7ExnV0qjXa155Rsfi6H8M4iBBwNLBM9lcVS+4NcSzOFaNqmt7djlox8pN1lWrRPMRRQ8NeDlozIGx3Omsw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.32.0':
     resolution: {integrity: sha512-VDzNHtLLI5s7xd/VubyS10mq6TxvZBp+4NRWoW+Hi3tgV05RtVm4qK99+dClwTN1McA6PHwob6DEJ6PlXbY83A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.32.0':
     resolution: {integrity: sha512-qcb9qYDlkxz9DxJo7SDhWxTWV1gFuwznjbTiov289pASxlfGbaOD54mgbs9+z94VwrXtKTu+2RqwlSTbiOqxGg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.32.0':
     resolution: {integrity: sha512-pFDdotFDMXW2AXVbfdUEfidPAk/OtwE/Hd4eYMTNVVaCQ6Yl8et0meDaKNL63L44Haxv4UExpv9ydSf3aSayDg==}
@@ -1027,6 +1040,9 @@ packages:
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  markdown-it-footnote@4.0.0:
+    resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -2314,6 +2330,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   mark.js@8.11.1: {}
+
+  markdown-it-footnote@4.0.0: {}
 
   markdown-it@14.1.0:
     dependencies:


### PR DESCRIPTION
- https://deploy-preview-88--luxury-mochi-9269a9.netlify.app/FAQ/mathcal_font.html#怎么把-cal-字体变成-latex-里-mathcal-默认的那种
- https://deploy-preview-88--luxury-mochi-9269a9.netlify.app/FAQ/symbol-mathscr.html#如何实现-mathscr-的花体符号

Co-authored-by: obj

另：开发版 typst 已经有专门的`math.scr`了。
https://ydx-typst.netlify.app/docs/reference/math/variants/#functions-scr