### PR TITLE
ci: Add the old typst executable to `$PATH`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,11 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
+        mkdir -p ~/.local/bin
+
         curl -OL https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz
         tar -xvf typst-x86_64-unknown-linux-musl.tar.xz
-        mv typst-x86_64-unknown-linux-musl/typst typst-0.13.1
+        mv typst-x86_64-unknown-linux-musl/typst ~/.local/bin/typst-0.13.1
         rm -r typst-x86_64-unknown-linux-musl
 
     - name: Restore cached fonts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,9 +23,11 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          mkdir -p ~/.local/bin
+
           curl -OL https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz
           tar -xvf typst-x86_64-unknown-linux-musl.tar.xz
-          mv typst-x86_64-unknown-linux-musl/typst typst-0.13.1
+          mv typst-x86_64-unknown-linux-musl/typst ~/.local/bin/typst-0.13.1
           rm -r typst-x86_64-unknown-linux-musl
 
       - name: Restore cached fonts

--- a/docs/.vitepress/typst_render.ts
+++ b/docs/.vitepress/typst_render.ts
@@ -23,7 +23,12 @@ const AVAILABLE_EXECUTABLES = await Promise.all([
 );
 assert(
   AVAILABLE_EXECUTABLES.includes('typst'),
-  `Failed to find the typst executable in PATH. Found: ${AVAILABLE_EXECUTABLES}`
+  `Failed to find the typst executable in $PATH. Found: ${
+    AVAILABLE_EXECUTABLES.join(', ')
+  }`,
+);
+console.log(
+  `Found available typst executables: ${AVAILABLE_EXECUTABLES.join(', ')}`,
 );
 
 /**
@@ -73,8 +78,9 @@ function compileTypst(
   // 输出设置
 
   // 计算源码的 SHA1 哈希值
-  const hash = createHash('sha1').update(`${src}\0${typst_executable}`).digest('hex')
-    .slice(0, 10);
+  const hash = createHash('sha1').update(
+    `cache-version: 2025-11-05\0${typst_executable}\0${src}`,
+  ).digest('hex').slice(0, 10);
   const outPrefix = 'docs/generated/';
   const pageFilePattern = `${outPrefix}${hash}_{n}.png`;
   const logFile = `${outPrefix}${hash}.log`;


### PR DESCRIPTION
之前的装的`typst-0.13.1`没放到`$PATH`上，出现了以下警告：

https://typst-doc-cn.github.io/guide/FAQ/equation-chinese-font.html#typst-0-13
<img width="300" alt="图片" src="https://github.com/user-attachments/assets/f776af82-4679-49b0-8dd1-2e08b4bf4bb5" />

正常应该这样：
https://luxury-mochi-9269a9.netlify.app/FAQ/equation-chinese-font.html#typst-0-13
<img width="300" alt="图片" src="https://github.com/user-attachments/assets/2d09d803-9a67-4c96-a629-e9c08d01a6ac" />
