### PR TITLE
fix: update cjk-unbreak version

### DIFF
--- a/docs/FAQ/chinese-remove-space.md
+++ b/docs/FAQ/chinese-remove-space.md
@@ -28,7 +28,7 @@ tags: [layout, text]
 
 ```typst
 -- #set page(width: auto, height: auto, margin: 1em)
-#import "@preview/cjk-unbreak:0.2.1": remove-cjk-break-space // [!code ++]
+#import "@preview/cjk-unbreak:0.2.3": remove-cjk-break-space // [!code ++]
 #show: remove-cjk-break-space // [!code ++]
 
 测试一下，
@@ -59,7 +59,7 @@ tags: [layout, text]
 
 ```typst
 -- #set page(width: auto, height: auto, margin: 1em)
-#import "@preview/cjk-unbreak:0.2.1": remove-cjk-break-space
+#import "@preview/cjk-unbreak:0.2.3": remove-cjk-break-space
 #show: remove-cjk-break-space
 
 “七斤嫂，你‘恨棒打人’。


### PR DESCRIPTION
`cjk-unbreak` has some bugs in `v0.2.1`. It has now been updated to `v0.2.3`, which is relatively stable.

If users use the previous, compilation errors may occur in some cases.