### PR TITLE
fix: 更正页面历史中的最后编辑时间

### DIFF
--- a/patches/@nolebase__vitepress-plugin-git-changelog.patch
+++ b/patches/@nolebase__vitepress-plugin-git-changelog.patch
@@ -1,5 +1,22 @@
+diff --git a/dist/client/components/Changelog.vue b/dist/client/components/Changelog.vue
+index c1716c10b04816ef22179ed738a7e4809aeaba76..28a094837ff5b7e198139daadbb1393bc406ef1e 100644
+--- a/dist/client/components/Changelog.vue
++++ b/dist/client/components/Changelog.vue
+@@ -25,7 +25,11 @@ const { commits, useHmr } = useChangelog()
+ // The order of commits, defaults to true (descending order)
+ const isDescending = ref(true)
+ const toggleViewMore = ref(false)
+-const lastChangeDate = ref<Date>(commits.value[0]?.date_timestamp ? toDate(commits.value[0]?.date_timestamp) : new Date())
++const lastChangeDate = computed<Date>(() => {
++  // Find the latest regular commit (excluding typst fake commits)
++  const last = commits.value.find(c => !c.tag)
++  return last?.date_timestamp ? toDate(last?.date_timestamp) : new Date()
++})
+ 
+ const locale = computed<Locale>(() => {
+   if (!options.locales || typeof options.locales === 'undefined')
 diff --git a/dist/client/composables/changelog.mjs b/dist/client/composables/changelog.mjs
-index f63b201c453809ad5a5797360ce3f55a70ee6581..cadb0547b88485f5a71bafbc79e1da480a5d9da5 100644
+index f63b201c453809ad5a5797360ce3f55a70ee6581..0d710d3bb31e2a157358dc503b32d3f7cf8ddf24 100644
 --- a/dist/client/composables/changelog.mjs
 +++ b/dist/client/composables/changelog.mjs
 @@ -2,6 +2,20 @@ import changelog from "virtual:nolebase-git-changelog";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@nolebase/vitepress-plugin-git-changelog':
-    hash: 4badcac8fb653967e0ffa7dcdd1f9222b7ef87a1a01c66dddc8559ea5bd95db6
+    hash: 616dace0668592bf5dc98c80c63ffa931449a071d3cc02bc116f844b9d4920cb
     path: patches/@nolebase__vitepress-plugin-git-changelog.patch
 
 importers:
@@ -22,7 +22,7 @@ importers:
     devDependencies:
       '@nolebase/vitepress-plugin-git-changelog':
         specifier: ^2.18.2
-        version: 2.18.2(patch_hash=4badcac8fb653967e0ffa7dcdd1f9222b7ef87a1a01c66dddc8559ea5bd95db6)(vitepress@2.0.0-alpha.17(@types/node@25.9.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(postcss@8.5.15))(vue@3.5.38)
+        version: 2.18.2(patch_hash=616dace0668592bf5dc98c80c63ffa931449a071d3cc02bc116f844b9d4920cb)(vitepress@2.0.0-alpha.17(@types/node@25.9.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(postcss@8.5.15))(vue@3.5.38)
       '@shikijs/transformers':
         specifier: ^4.2.0
         version: 4.2.0
@@ -1991,7 +1991,7 @@ snapshots:
       vitepress: 2.0.0-alpha.17(@types/node@25.9.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(postcss@8.5.15)
       vue: 3.5.38
 
-  '@nolebase/vitepress-plugin-git-changelog@2.18.2(patch_hash=4badcac8fb653967e0ffa7dcdd1f9222b7ef87a1a01c66dddc8559ea5bd95db6)(vitepress@2.0.0-alpha.17(@types/node@25.9.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(postcss@8.5.15))(vue@3.5.38)':
+  '@nolebase/vitepress-plugin-git-changelog@2.18.2(patch_hash=616dace0668592bf5dc98c80c63ffa931449a071d3cc02bc116f844b9d4920cb)(vitepress@2.0.0-alpha.17(@types/node@25.9.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(postcss@8.5.15))(vue@3.5.38)':
     dependencies:
       '@iconify-json/octicon': 1.2.28
       '@nolebase/ui': 2.18.2(vitepress@2.0.0-alpha.17(@types/node@25.9.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(postcss@8.5.15))(vue@3.5.38)


### PR DESCRIPTION
之前 #166 插入了 Typst 历史版本，而计算最后编辑时间应排除 Typst 历史版本。
